### PR TITLE
Add GH action which updates *.svg plots

### DIFF
--- a/.github/workflows/update_plots.yaml
+++ b/.github/workflows/update_plots.yaml
@@ -1,0 +1,29 @@
+name: Update plots
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-r:
+    name: Run .Rmd and save generated .svgs
+    # Update plots only if commit message contains keywords 'Add data' (not case-sensitive)
+    if: "contains(github.event.head_commit.message, 'Add data')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
+      - name: Install needed R packages
+        run: |
+          R -e "install.packages('knitr')"
+      - name: Knit .Rmd to generate plots (and .md)
+        run: |
+          R -e "knitr::knit('README.Rmd')"
+      - name: Commit generated plots
+        run: |
+          git config --local user.name "Update Action"
+          git config --local user.email "actions@github.com"
+          git add *.svg
+          git commit -m 'Update plots' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"


### PR DESCRIPTION
This PR adds a GitHub Action which updates the `*.svg` plots. The action gets automatically triggered when a commit message contains the keywords `add data`. The action then sets up a machine with R and the `knitr` package to knit the `README.Rmd`. All the produced files which match the expression `*.svg` will then be committed to the current branch.

The action will be triggered no matter whether the data in the relevant `.csv` changed. The only condition is that the commit message has to include `add data` (not case-sensitive).