### PR TITLE
Execute `knit` command via Makefile

### DIFF
--- a/.github/workflows/update_plots.yaml
+++ b/.github/workflows/update_plots.yaml
@@ -17,9 +17,9 @@ jobs:
       - name: Install needed R packages
         run: |
           R -e "install.packages('knitr')"
-      - name: Knit .Rmd to generate plots (and .md)
+      - name: Make README and *.svg plots
         run: |
-          R -e "knitr::knit('README.Rmd')"
+          make README.md
       - name: Commit generated plots
         run: |
           git config --local user.name "Update Action"


### PR DESCRIPTION
The workflow `Update plots` will execute the command `knittr::knit` via the `Makefile`. This ensures the DRY principle and makes it easier to reproduce the workflow locally. Furthermore, it does not update the plots if the `uw_covid_2022.csv` is not up to date.