### PR TITLE
Cache Python dependencies

### DIFF
--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -19,10 +19,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Detect and install Python dependencies
+          cache: pip # Cache pip dependencies
+      - name: Install Python dependencies
         run: |
-          pip install pipreqs
-          pipreqs .
           pip install -r requirements.txt
 
       - name: Remove old files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas==1.5.1
+requests==2.25.1
+requests_html==0.10.0


### PR DESCRIPTION
To speed up the execution, we should cache dependencies throughout different runs by avoiding downloading them again. This PR introduces caching for Python. The important difference is that this requires a file with the needed Python dependencies upfront, i.e. `requirements.txt`. 

When changing the Python script, remember to keep the `requirements.txt` in sync. If your IDE does not offer this functionality, you can consider the Python helper package `pipreqs`.